### PR TITLE
Verify installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,11 @@ jobs:
         with:
           lfc-version: ${{matrix.lfc}}
           lingo-version: ${{matrix.lingo}}
+        
+      - name: Smoke test LFC
+        run: lfc --version
+        shell: bash
+      
+      - name: Smoke test lingo
+        run: lingo --version
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: lf-lang/action-setup-lf@v0.1
+      - uses: lf-lang/action-setup-lf@v0.2
         with:
           lfc-version: stable
           lingo-version: stable
@@ -25,7 +25,7 @@ jobs:
 
 For latest nightly release of lfc and v0.2.0 of lingo:
 ```yaml
-      - uses: lf-lang/action-setup-lf@v0.1
+      - uses: lf-lang/action-setup-lf@v0.2
         with:
           lfc-version: nightly
           lingo-version: 0.2.0

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Install LFC (macOS)
       if: runner.os == 'macOS'
       run: |
-        bash ./tmp/installation/install.sh cli ${{ inputs.lfc-version }} --prefix=$HOME/.local && break
+        bash ./tmp/installation/install.sh cli ${{ inputs.lfc-version }} --prefix=$HOME/.local
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       shell: bash
     - name: Install lingo

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Install LFC (macOS)
       if: runner.os == 'macOS'
       run: |
-        bash ./tmp/installation/install.sh cli ${{ inputs.lfc-version }} --prefix=$HOME/.local
+        bash ./tmp/installation/install.sh cli ${{ inputs.lfc-version }} --prefix=$HOME/.local && break
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       shell: bash
     - name: Install lingo


### PR DESCRIPTION
THis PR adds a `lfc --version` and `lingo --version` to CI so we can verify that they were successfully installed, and are available on the path.

This currently fails for macOS